### PR TITLE
Update A_RS2_CDS_OpportunityUpdateUtilityTest.cls

### DIFF
--- a/A_RS2_CDS_OpportunityUpdateUtilityTest.cls
+++ b/A_RS2_CDS_OpportunityUpdateUtilityTest.cls
@@ -24,7 +24,6 @@ public class A_RS2_CDS_OpportunityUpdateUtilityTest
       
       oppList.add(opp2);
       
-      insert oppList;
       
       oppList=[select Opportunity_Id__c from opportunity where id in:oppList];
       


### PR DESCRIPTION
### **PR Type**
tests


___

### **Description**
- Removed the insertion of the `oppList` into the database in the `A_RS2_CDS_OpportunityUpdateUtilityTest` class.
- Adjusted the test setup to avoid persisting test data, likely to improve test isolation or performance.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>A_RS2_CDS_OpportunityUpdateUtilityTest.cls</strong><dd><code>Modify test setup by removing database insertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

A_RS2_CDS_OpportunityUpdateUtilityTest.cls

<li>Removed the insertion of <code>oppList</code> into the database.<br> <li> Adjusted the test setup by not persisting test data.<br>


</details>


  </td>
  <td><a href="https://github.com/rayraja1992/TestRepo5/pull/2/files#diff-2b28b42049d95adc52c4d87576b9246065cd5c064496d473d3706f3ceddbe3da">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified the `testOppUpdateUtility6` method to prevent the insertion of Opportunity records, improving test accuracy.
- **Tests**
	- Retained Opportunity record insertion in the `testOppUpdateUtility1` method to ensure proper testing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->